### PR TITLE
Allow users to resize image to specified size

### DIFF
--- a/thumbor-builder.php
+++ b/thumbor-builder.php
@@ -44,9 +44,9 @@ Class Thumbor_Builder {
 
 			$image_url->addFilter( 'format', $builder_args['format'] );
 		}
-
+		
 		if ( isset( $builder_args['fill'] ) ) {
-			$image_url->addFilter( $builder_args['fill'], true);
+			$image_url->addFilter( 'fill', $builder_args['fill'], 1);
 		}
 		
 		return $image_url;

--- a/thumbor-builder.php
+++ b/thumbor-builder.php
@@ -45,6 +45,10 @@ Class Thumbor_Builder {
 			$image_url->addFilter( 'format', $builder_args['format'] );
 		}
 
+		if ( isset( $builder_args['fill'] ) ) {
+			$image_url->addFilter( $builder_args['fill'], true);
+		}
+		
 		return $image_url;
 	}
 


### PR DESCRIPTION
When original image is smaller than the requested size - thumbor will not by default fill it up to the requested size.
`filters:fill($color='white', $transparency=true)`   - one of the ways to handle it..

practical example:
Original image Width*Height :  300*300
Requested Image is 500*500 ... Thumbor will return 300x300
Applying filter `filters:fill('white',true)`  - will use white color as a background to make an image of requested dimensions 500x500 without stretching the actual image.

I would allow users to use the same existing filter to add this condition in the format: fill='color'.
thumbor.php line #82 :
```
		// Let people filter the args
		$builder_args = apply_filters( 'thumbor_builder_args', $builder_args, $image_url, $additional_builder_args );
```

filter should add value to the 
```
	add_filter('thumbor_builder_args', 'vip_thumbor_add_image_background_color_to_fit_size', 3);
	function vip_thumbor_add_image_background_color_to_fit_size($builder_args, $image_url, $additional_builder_args)
	{
		$builder_args['fill'] = 'white';
		return $builder_args;
	}
```