### PR TITLE
add_filter to allow domain substitution for devel

### DIFF
--- a/thumbor.php
+++ b/thumbor.php
@@ -82,6 +82,8 @@ Class Thumbor {
 		// Let people filter the args
 		$builder_args = apply_filters( 'thumbor_builder_args', $builder_args, $image_url, $additional_builder_args );
 
+		$image_url = apply_filters( 'thumbor_image_url_src', $image_url );
+
 		// Check if image URL should be used.
 		if ( ! $builder->validate_image_url( $image_url ) ) {
 			return false;


### PR DESCRIPTION
Add filter to substitute the domain name in the image url, it would be useful for testing in QA / Staging environments.

example of usage:
```
	if (WP_ENV == 'development') {
		add_filter('thumbor_image_url_src', 'vip_thumbor_change_development_hostname');
		function vip_thumbor_change_development_hostname($image_url)
		{
			return str_replace(WP_HOME, 'https://example.com', $image_url);
		}
	}
```